### PR TITLE
Make calfile directory import-able

### DIFF
--- a/wedgie/__init__.py
+++ b/wedgie/__init__.py
@@ -1,6 +1,12 @@
 """init file for wedgie"""
+import os
+import sys
 from .cosmo_utils import *
 from .gen_utils import *
 from .wedge_utils import *
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
+CAL_DIR = os.path.join(ROOT, 'calibrations')
+sys.path.append(CAL_DIR)
 
 __version__ = 0.1


### PR DESCRIPTION
This PR adds the directory containing calfiles to the user's path on importing the package. When running the code using a calfile, the directory that contains calfiles (`wedgie/calibrations`) is added to the path, and so is import-able. This does not require the user to worry about modifying the PYTHONPATH environment variable or manually editing their path inside python.